### PR TITLE
Add support for Custom Grouping

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 17329f7f85fc6a7a3029086b63b50437f1ef75fc7f5453043d24c6ed1307ac4f
-updated: 2018-10-24T11:37:52.581859412+05:00
+updated: 2019-01-30T19:50:20.266282+01:00
 imports:
 - name: github.com/emicklei/go-restful
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
@@ -73,7 +73,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/magiconair/properties
-  version: c2353362d570a7bfa228149c62842019201cfb71
+  version: 7757cc9fdb852f7579b24170bcacda2c7471bb6a
 - name: github.com/mailru/easyjson
   version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
@@ -81,13 +81,13 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/mitchellh/mapstructure
-  version: 3536a929edddb9a5b34bd6861dc4a9647cb459fe
+  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
 - name: github.com/onrik/logrus
-  version: c9849815bc7c2abf20d58e4bc06c242198ebb741
+  version: 05335c5abaa99d4c7a3f36df162b483106ef38a8
   subpackages:
   - filename
 - name: github.com/pelletier/go-toml
-  version: 81a861c69d25a841d0c4394f0e6f84bc8c5afae0
+  version: 27c6b39a135b7dc87a14afb068809132fb7a9a8f
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pkg/errors
@@ -99,15 +99,15 @@ imports:
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/spf13/afero
-  version: d40851caa0d747393da1ffb28f7f9d8b4eeffebd
+  version: f4711e4db9e9a1d3887343acb72b2bbfc2f686f5
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: efb632f0f61348654b631fd11da5ff457a5ca2ef
+  version: 8c9545af88b134710ab1cd196795e7f2388358d7
 - name: github.com/spf13/jwalterweatherman
-  version: 103a6da826d08544f49833dabd4f1cdf8a1038bb
+  version: 94f6ae3ed3bceceafa716478c5fbf8d29ca601a1
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
   version: 2c12c60302a5a0e62ee102ca9bc996277c2f64f5
 - name: golang.org/x/crypto
@@ -143,7 +143,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
   version: 006a217681ae70cbacdd66a5e2fca1a61a8ff28e
   subpackages:

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,4 +1,4 @@
-package apps
+package annotations
 
 const (
 	// IngressClassAnnotation const used for checking ingress class

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -9,4 +9,6 @@ const (
 	ForecastleExposeAnnotation = "forecastle.stakater.com/expose"
 	// ForecastleAppNameAnnotation const used for overriding the name of the app
 	ForecastleAppNameAnnotation = "forecastle.stakater.com/appName"
+	// ForecastleGroupAnnotation const used for overriding group
+	ForecastleGroupAnnotation = "forecastle.stakater.com/group"
 )

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"github.com/stakater/Forecastle/pkg/annotations"
 	"github.com/stakater/Forecastle/pkg/kube/lists/ingresses"
 	"github.com/stakater/Forecastle/pkg/kube/wrappers"
 	"k8s.io/api/extensions/v1beta1"
@@ -44,12 +45,12 @@ func (al *List) Get() ([]ForecastleApp, error) {
 
 func convertIngressesToForecastleApps(ingresses []v1beta1.Ingress) (apps []ForecastleApp) {
 	for _, ingress := range ingresses {
-		wrapper := wrappers.NewIngressWrapper(&ingress, ForecastleAppNameAnnotation)
+		wrapper := wrappers.NewIngressWrapper(&ingress)
 		apps = append(apps, ForecastleApp{
-			Name:      wrapper.GetName(),
-			Namespace: wrapper.GetNamespace(),
-			Icon:      wrapper.GetAnnotationValue(ForecastleIconAnnotation),
-			URL:       wrapper.GetURL(),
+			Name:  wrapper.GetName(),
+			Group: wrapper.GetNamespace(),
+			Icon:  wrapper.GetAnnotationValue(annotations.ForecastleIconAnnotation),
+			URL:   wrapper.GetURL(),
 		})
 	}
 	return

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -48,7 +48,7 @@ func convertIngressesToForecastleApps(ingresses []v1beta1.Ingress) (apps []Forec
 		wrapper := wrappers.NewIngressWrapper(&ingress)
 		apps = append(apps, ForecastleApp{
 			Name:  wrapper.GetName(),
-			Group: wrapper.GetNamespace(),
+			Group: wrapper.GetGroup(),
 			Icon:  wrapper.GetAnnotationValue(annotations.ForecastleIconAnnotation),
 			URL:   wrapper.GetURL(),
 		})

--- a/pkg/apps/apps_test.go
+++ b/pkg/apps/apps_test.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stakater/Forecastle/pkg/annotations"
 	"github.com/stakater/Forecastle/pkg/testutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -69,19 +70,19 @@ func TestList_Get(t *testing.T) {
 				kubeClient: kubeClient,
 				items: []ForecastleApp{
 					{
-						Name:      "app",
-						Icon:      "https://google.com/icon.png",
-						Namespace: "test",
-						URL:       "https://google.com",
+						Name:  "app",
+						Icon:  "https://google.com/icon.png",
+						Group: "test",
+						URL:   "https://google.com",
 					},
 				},
 			},
 			want: []ForecastleApp{
 				{
-					Name:      "app",
-					Icon:      "https://google.com/icon.png",
-					Namespace: "test",
-					URL:       "https://google.com",
+					Name:  "app",
+					Icon:  "https://google.com/icon.png",
+					Group: "test",
+					URL:   "https://google.com",
 				},
 			},
 			wantErr: false,
@@ -136,15 +137,15 @@ func Test_convertIngressesToForecastleApps(t *testing.T) {
 			args: args{
 				ingresses: []v1beta1.Ingress{
 					*testutil.AddAnnotationToIngress(testutil.CreateIngressWithHost("test-ingress", "google.com"),
-						ForecastleIconAnnotation, "https://google.com/icon.png"),
+						annotations.ForecastleIconAnnotation, "https://google.com/icon.png"),
 				},
 			},
 			wantApps: []ForecastleApp{
 				{
-					Name:      "test-ingress",
-					Namespace: "",
-					Icon:      "https://google.com/icon.png",
-					URL:       "http://google.com",
+					Name:  "test-ingress",
+					Group: "",
+					Icon:  "https://google.com/icon.png",
+					URL:   "http://google.com",
 				},
 			},
 		},
@@ -163,8 +164,8 @@ func TestList_Populate(t *testing.T) {
 
 	ingress := testutil.AddAnnotationToIngress(
 		testutil.AddAnnotationToIngress(
-			testutil.CreateIngressWithHost("test-ingress", "google.com"), ForecastleExposeAnnotation, "true"),
-		IngressClassAnnotation, "ingress")
+			testutil.CreateIngressWithHost("test-ingress", "google.com"), annotations.ForecastleExposeAnnotation, "true"),
+		annotations.IngressClassAnnotation, "ingress")
 
 	_, _ = kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "testing"}})
 	_, _ = kubeClient.ExtensionsV1beta1().Ingresses("default").Create(ingress)
@@ -196,14 +197,14 @@ func TestList_Populate(t *testing.T) {
 				kubeClient: kubeClient,
 				items: []ForecastleApp{
 					{
-						Name:      "test-ingress",
-						Namespace: "default",
-						URL:       "http://google.com",
+						Name:  "test-ingress",
+						Group: "default",
+						URL:   "http://google.com",
 					},
 					{
-						Name:      "test-ingress",
-						Namespace: "testing",
-						URL:       "http://google.com",
+						Name:  "test-ingress",
+						Group: "testing",
+						URL:   "http://google.com",
 					},
 				},
 			},
@@ -220,14 +221,14 @@ func TestList_Populate(t *testing.T) {
 				kubeClient: kubeClient,
 				items: []ForecastleApp{
 					{
-						Name:      "test-ingress",
-						Namespace: "default",
-						URL:       "http://google.com",
+						Name:  "test-ingress",
+						Group: "default",
+						URL:   "http://google.com",
 					},
 					{
-						Name:      "test-ingress",
-						Namespace: "testing",
-						URL:       "http://google.com",
+						Name:  "test-ingress",
+						Group: "testing",
+						URL:   "http://google.com",
 					},
 				},
 			},
@@ -244,9 +245,9 @@ func TestList_Populate(t *testing.T) {
 				kubeClient: kubeClient,
 				items: []ForecastleApp{
 					{
-						Name:      "test-ingress",
-						Namespace: "testing",
-						URL:       "http://google.com",
+						Name:  "test-ingress",
+						Group: "testing",
+						URL:   "http://google.com",
 					},
 				},
 			},

--- a/pkg/apps/filters.go
+++ b/pkg/apps/filters.go
@@ -1,10 +1,13 @@
 package apps
 
-import "k8s.io/api/extensions/v1beta1"
+import (
+	"github.com/stakater/Forecastle/pkg/annotations"
+	"k8s.io/api/extensions/v1beta1"
+)
 
 // For filtering ingresses having ingress class annotation
 func byIngressClassAnnotation(ingress v1beta1.Ingress) bool {
-	if _, ok := ingress.Annotations[IngressClassAnnotation]; ok {
+	if _, ok := ingress.Annotations[annotations.IngressClassAnnotation]; ok {
 		return true
 	}
 	return false
@@ -12,7 +15,7 @@ func byIngressClassAnnotation(ingress v1beta1.Ingress) bool {
 
 // For filtering ingressing having forecastle expose annotation set to true
 func byForecastleExposeAnnotation(ingress v1beta1.Ingress) bool {
-	if val, ok := ingress.Annotations[ForecastleExposeAnnotation]; ok {
+	if val, ok := ingress.Annotations[annotations.ForecastleExposeAnnotation]; ok {
 		// Has Forecastle annotation and is exposed
 		if val == "true" {
 			return true

--- a/pkg/apps/filters_test.go
+++ b/pkg/apps/filters_test.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"testing"
 
+	"github.com/stakater/Forecastle/pkg/annotations"
 	"github.com/stakater/Forecastle/pkg/testutil"
 	"k8s.io/api/extensions/v1beta1"
 )
@@ -27,7 +28,7 @@ func Test_byIngressClassAnnotation(t *testing.T) {
 			name: "TestByIngressClassAnnotationWithAnnotation",
 			args: args{
 				ingress: *testutil.AddAnnotationToIngress(
-					testutil.CreateIngress("test-ingress"), IngressClassAnnotation, "internal-ingress"),
+					testutil.CreateIngress("test-ingress"), annotations.IngressClassAnnotation, "internal-ingress"),
 			},
 			want: true,
 		},
@@ -61,7 +62,7 @@ func Test_byForecastleExposeAnnotation(t *testing.T) {
 			name: "TestByForecastleExposeAnnotationWithAnnotationsFalseValue",
 			args: args{
 				ingress: *testutil.AddAnnotationToIngress(
-					testutil.CreateIngress("test-ingress"), ForecastleExposeAnnotation, "false"),
+					testutil.CreateIngress("test-ingress"), annotations.ForecastleExposeAnnotation, "false"),
 			},
 			want: false,
 		},
@@ -69,7 +70,7 @@ func Test_byForecastleExposeAnnotation(t *testing.T) {
 			name: "TestByForecastleExposeAnnotationWithTrueValue",
 			args: args{
 				ingress: *testutil.AddAnnotationToIngress(
-					testutil.CreateIngress("test-ingress"), ForecastleExposeAnnotation, "true"),
+					testutil.CreateIngress("test-ingress"), annotations.ForecastleExposeAnnotation, "true"),
 			},
 			want: true,
 		},

--- a/pkg/apps/forecastle.go
+++ b/pkg/apps/forecastle.go
@@ -2,8 +2,8 @@ package apps
 
 // ForecastleApp struct that contains information about an app that is exposed to forecastle
 type ForecastleApp struct {
-	Name      string
-	Icon      string
-	Namespace string
-	URL       string
+	Name  string
+	Icon  string
+	Group string
+	URL   string
 }

--- a/pkg/kube/wrappers/ingress.go
+++ b/pkg/kube/wrappers/ingress.go
@@ -12,8 +12,7 @@ var (
 
 // IngressWrapper struct wraps a kubernetes ingress object
 type IngressWrapper struct {
-	ingress           *v1beta1.Ingress
-	appNameAnnotation string
+	ingress *v1beta1.Ingress
 }
 
 // NewIngressWrapper func creates an instance of IngressWrapper
@@ -42,6 +41,14 @@ func (iw *IngressWrapper) GetName() string {
 // GetNamespace func extracts namespace of the ingress wrapped by the object
 func (iw *IngressWrapper) GetNamespace() string {
 	return iw.ingress.ObjectMeta.Namespace
+}
+
+// GetGroup func extracts group name from the ingress
+func (iw *IngressWrapper) GetGroup() string {
+	if groupFromAnnotation := iw.GetAnnotationValue(annotations.ForecastleGroupAnnotation); groupFromAnnotation != "" {
+		return groupFromAnnotation
+	}
+	return iw.GetNamespace()
 }
 
 // GetURL func extracts url of the ingress wrapped by the object

--- a/pkg/kube/wrappers/ingress.go
+++ b/pkg/kube/wrappers/ingress.go
@@ -1,6 +1,7 @@
 package wrappers
 
 import (
+	"github.com/stakater/Forecastle/pkg/annotations"
 	"github.com/stakater/Forecastle/pkg/log"
 	"k8s.io/api/extensions/v1beta1"
 )
@@ -16,10 +17,9 @@ type IngressWrapper struct {
 }
 
 // NewIngressWrapper func creates an instance of IngressWrapper
-func NewIngressWrapper(ingress *v1beta1.Ingress, appNameAnnotation string) *IngressWrapper {
+func NewIngressWrapper(ingress *v1beta1.Ingress) *IngressWrapper {
 	return &IngressWrapper{
-		ingress:           ingress,
-		appNameAnnotation: appNameAnnotation,
+		ingress: ingress,
 	}
 }
 
@@ -33,7 +33,7 @@ func (iw *IngressWrapper) GetAnnotationValue(annotationKey string) string {
 
 // GetName func extracts name of the ingress wrapped by the object
 func (iw *IngressWrapper) GetName() string {
-	if nameFromAnnotation := iw.GetAnnotationValue(iw.appNameAnnotation); nameFromAnnotation != "" {
+	if nameFromAnnotation := iw.GetAnnotationValue(annotations.ForecastleAppNameAnnotation); nameFromAnnotation != "" {
 		return nameFromAnnotation
 	}
 	return iw.ingress.ObjectMeta.Name

--- a/pkg/kube/wrappers/ingress_test.go
+++ b/pkg/kube/wrappers/ingress_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stakater/Forecastle/pkg/annotations"
+
 	"github.com/stakater/Forecastle/pkg/testutil"
 	"k8s.io/api/extensions/v1beta1"
 )
@@ -29,7 +31,7 @@ func TestNewIngressWrapper(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewIngressWrapper(tt.args.ingress, ""); !reflect.DeepEqual(got, tt.want) {
+			if got := NewIngressWrapper(tt.args.ingress); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewIngressWrapper() = %v, want %v", got, tt.want)
 			}
 		})
@@ -451,6 +453,42 @@ func TestIngressWrapper_getIngressSubPath(t *testing.T) {
 			}
 			if got := iw.getIngressSubPath(); got != tt.want {
 				t.Errorf("IngressWrapper.getIngressSubPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIngressWrapper_GetGroup(t *testing.T) {
+	type fields struct {
+		ingress *v1beta1.Ingress
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "IngressWithoutGroup",
+			fields: fields{
+				ingress: testutil.CreateIngressWithNamespace("someIngress", "test"),
+			},
+			want: "test",
+		},
+		{
+			name: "IngressWithGroup",
+			fields: fields{
+				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithNamespace("someIngress", "test"), annotations.ForecastleGroupAnnotation, "My Group"),
+			},
+			want: "My Group",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iw := &IngressWrapper{
+				ingress: tt.fields.ingress,
+			}
+			if got := iw.GetGroup(); got != tt.want {
+				t.Errorf("IngressWrapper.GetGroup() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/static/assets/js/custom.js
+++ b/static/assets/js/custom.js
@@ -22,11 +22,11 @@ jQuery(document).ready(function($){
     
         });
 
-        $('.namespace').each(function() {
+        $('.group').each(function() {
             if ($(this).find(".app").filter(":visible").length == 0) {
-                $(this).find(".namespace-header").hide();
+                $(this).find(".group-header").hide();
             } else {
-                $(this).find(".namespace-header").show();
+                $(this).find(".group-header").show();
             }
         });
     
@@ -45,7 +45,7 @@ jQuery(document).ready(function($){
     }
 
     function populateAppsListFromJson(data) {
-        data = groupByKeys(data, "Namespace", "Apps");
+        data = groupByKeys(data, "Group", "Apps");
         $.each(data, renderApp);
         initSearch();
     }

--- a/static/index.html
+++ b/static/index.html
@@ -132,12 +132,12 @@
 </body>
 
 <script id="app-template" type="text/x-handlebars-template">
-<div class="namespace">
-    <div class="namespace-header">
-        <h2 class="mt-3 text-capitalize">{{Namespace}}</h2>
+<div class="group">
+    <div class="group-header">
+        <h2 class="mt-3 text-capitalize">{{Group}}</h2>
         <hr class="mt-0" />
     </div>
-    <div class="namespace-content">
+    <div class="group-content">
         <div class="row">
         {{#each Apps}}
             <div class="col-3 app my-2">


### PR DESCRIPTION
- With this PR, you can control which app belongs to which group, regardless of which namespace it is in. So if you have everything running in just 1 namespace, you can still group apps in different groups using annotation `forecastle.stakater.com/groupName`

Fixes #35 