### PR TITLE
Add support for overriding a URL using annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ src/node_modules
 .idea
 api/vendor
 vendor
+Forecastle
+config.yaml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Forecastle looks for a specific annotations on ingresses.
 | `forecastle.stakater.com/appName`  | A custom name for your application. Use if you don't want to use name of the ingress                                                                      | `false`  |
 | `forecastle.stakater.com/group`    | A custom group name. Use if you want the application to show in a different group than the namespace it is running in                                     | `false`  |
 | `forecastle.stakater.com/instance` | A comma separated list of name/s of the forecastle instance/s where you want this application to appear. Use when you have multiple forecastle dashboards | `false`  |
-| `forecastle.stakater.com/appRoot`  | Can be used to set a different root path of the ingress URL if required                                                                                   | `false`  |
+| `forecastle.stakater.com/url`  | A URL for the forecastle app (This will override the ingress URL). It MUST begin with a scheme i.e., `http://` or `https://`                                  | `false`  |
 
 ### Forecastle
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ Forecastle looks for a specific annotations on ingresses.
 
 - Add the following annotations to your ingresses in order to be discovered by forecastle:
 
-|           Annotation           |                                           Description                                           |
-|:------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| `forecastle.stakater.com/expose` | **[Required]** Add this with value `true` to the ingress of the app you want to show in Forecastle  |
-| `forecastle.stakater.com/icon`   | **[Optional]** Icon/Image URL of the application; An icons/logos/images collection repo [Icons](https://github.com/stakater/ForecastleIcons) |
-| `forecastle.stakater.com/appName` | **[Optional]** A custom name for your application. Use if you don't want to use name of the ingress |
-| `forecastle.stakater.com/group` | **[Optional]** A custom group name. Use if you want the application to show in a different group than the namespace it is running in |
-| `forecastle.stakater.com/instance` | | **[Optional]** A comma separated list of name/s of the forecastle instance/s where you want this application to appear. Use when you have multiple forecastle dashboards |
+| Annotation                         | Description                                                                                                                                               | Required |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `forecastle.stakater.com/expose`   | Add this with value `true` to the ingress of the app you want to show in Forecastle                                                                       | `true`   |
+| `forecastle.stakater.com/icon`     | Icon/Image URL of the application; An icons/logos/images collection repo [Icons](https://github.com/stakater/ForecastleIcons)                             | `false`  |
+| `forecastle.stakater.com/appName`  | A custom name for your application. Use if you don't want to use name of the ingress                                                                      | `false`  |
+| `forecastle.stakater.com/group`    | A custom group name. Use if you want the application to show in a different group than the namespace it is running in                                     | `false`  |
+| `forecastle.stakater.com/instance` | A comma separated list of name/s of the forecastle instance/s where you want this application to appear. Use when you have multiple forecastle dashboards | `false`  |
+| `forecastle.stakater.com/appRoot`  | Can be used to set a different root path of the ingress URL if required                                                                                   | `false`  |
 
 ### Forecastle
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -13,4 +13,6 @@ const (
 	ForecastleGroupAnnotation = "forecastle.stakater.com/group"
 	// ForecastleInstanceAnnotation const used for defining which instance of forecastle to use
 	ForecastleInstanceAnnotation = "forecastle.stakater.com/instance"
+	// ForecastleAppRootAnnotation const used for specifying the root of an app if other than '/'
+	ForecastleAppRootAnnotation = "forecastle.stakater.com/appRoot"
 )

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -13,6 +13,6 @@ const (
 	ForecastleGroupAnnotation = "forecastle.stakater.com/group"
 	// ForecastleInstanceAnnotation const used for defining which instance of forecastle to use
 	ForecastleInstanceAnnotation = "forecastle.stakater.com/instance"
-	// ForecastleAppRootAnnotation const used for specifying the root of an app if other than '/'
-	ForecastleAppRootAnnotation = "forecastle.stakater.com/appRoot"
+	// ForecastleURLAnnotation const used for specifying the URL for the forecastle app
+	ForecastleURLAnnotation = "forecastle.stakater.com/url"
 )

--- a/pkg/kube/wrappers/ingress.go
+++ b/pkg/kube/wrappers/ingress.go
@@ -70,8 +70,11 @@ func (iw *IngressWrapper) GetURL() string {
 	// Append port + ingressSubPath
 	url += iw.getIngressSubPath()
 
-	return url
+	return url + iw.getAppRoot()
+}
 
+func (iw *IngressWrapper) getAppRoot() string {
+	return iw.GetAnnotationValue(annotations.ForecastleAppRootAnnotation)
 }
 
 func (iw *IngressWrapper) rulesExist() bool {

--- a/pkg/kube/wrappers/ingress.go
+++ b/pkg/kube/wrappers/ingress.go
@@ -1,6 +1,8 @@
 package wrappers
 
 import (
+	"net/url"
+
 	"github.com/stakater/Forecastle/pkg/annotations"
 	"github.com/stakater/Forecastle/pkg/log"
 	"k8s.io/api/extensions/v1beta1"
@@ -54,6 +56,15 @@ func (iw *IngressWrapper) GetGroup() string {
 // GetURL func extracts url of the ingress wrapped by the object
 func (iw *IngressWrapper) GetURL() string {
 
+	if urlFromAnnotation := iw.GetAnnotationValue(annotations.ForecastleURLAnnotation); urlFromAnnotation != "" {
+		parsedURL, err := url.ParseRequestURI(urlFromAnnotation)
+		if err != nil {
+			logger.Warn(err)
+			return ""
+		}
+		return parsedURL.String()
+	}
+
 	if !iw.rulesExist() {
 		logger.Warn("No rules exist in ingress: ", iw.ingress.GetName())
 		return ""
@@ -70,11 +81,7 @@ func (iw *IngressWrapper) GetURL() string {
 	// Append port + ingressSubPath
 	url += iw.getIngressSubPath()
 
-	return url + iw.getAppRoot()
-}
-
-func (iw *IngressWrapper) getAppRoot() string {
-	return iw.GetAnnotationValue(annotations.ForecastleAppRootAnnotation)
+	return url
 }
 
 func (iw *IngressWrapper) rulesExist() bool {

--- a/pkg/kube/wrappers/ingress_test.go
+++ b/pkg/kube/wrappers/ingress_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stakater/Forecastle/pkg/annotations"
-
 	"github.com/stakater/Forecastle/pkg/testutil"
 	"k8s.io/api/extensions/v1beta1"
 )
@@ -410,6 +409,42 @@ func TestIngressWrapper_GetGroup(t *testing.T) {
 			}
 			if got := iw.GetGroup(); got != tt.want {
 				t.Errorf("IngressWrapper.GetGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIngressWrapper_getAppRoot(t *testing.T) {
+	type fields struct {
+		ingress *v1beta1.Ingress
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "IngressWithoutAppRoot",
+			fields: fields{
+				ingress: testutil.CreateIngressWithNamespace("someIngress", "test"),
+			},
+			want: "",
+		},
+		{
+			name: "IngressWithAppRoot",
+			fields: fields{
+				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithNamespace("someIngress", "test"), annotations.ForecastleAppRootAnnotation, "/test"),
+			},
+			want: "/test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iw := &IngressWrapper{
+				ingress: tt.fields.ingress,
+			}
+			if got := iw.getAppRoot(); got != tt.want {
+				t.Errorf("IngressWrapper.getAppRoot() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/kube/wrappers/ingress_test.go
+++ b/pkg/kube/wrappers/ingress_test.go
@@ -178,6 +178,27 @@ func TestIngressWrapper_GetURL(t *testing.T) {
 			},
 			want: "https://google.com",
 		},
+		{
+			name: "IngressWithValidHostWithOverridenURLWithoutScheme",
+			fields: fields{
+				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithHost("someIngress1", "google.com"), annotations.ForecastleURLAnnotation, "someotherurl.com"),
+			},
+			want: "",
+		},
+		{
+			name: "IngressWithValidHostWithOverridenURLWithScheme",
+			fields: fields{
+				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithHost("someIngress1", "google.com"), annotations.ForecastleURLAnnotation, "https://someotherurl.com"),
+			},
+			want: "https://someotherurl.com",
+		},
+		{
+			name: "IngressWithValidHostWithOverridenInvalidURL",
+			fields: fields{
+				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithHost("someIngress1", "google.com"), annotations.ForecastleURLAnnotation, "someotherurl42"),
+			},
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -409,42 +430,6 @@ func TestIngressWrapper_GetGroup(t *testing.T) {
 			}
 			if got := iw.GetGroup(); got != tt.want {
 				t.Errorf("IngressWrapper.GetGroup() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestIngressWrapper_getAppRoot(t *testing.T) {
-	type fields struct {
-		ingress *v1beta1.Ingress
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "IngressWithoutAppRoot",
-			fields: fields{
-				ingress: testutil.CreateIngressWithNamespace("someIngress", "test"),
-			},
-			want: "",
-		},
-		{
-			name: "IngressWithAppRoot",
-			fields: fields{
-				ingress: testutil.AddAnnotationToIngress(testutil.CreateIngressWithNamespace("someIngress", "test"), annotations.ForecastleAppRootAnnotation, "/test"),
-			},
-			want: "/test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			iw := &IngressWrapper{
-				ingress: tt.fields.ingress,
-			}
-			if got := iw.getAppRoot(); got != tt.want {
-				t.Errorf("IngressWrapper.getAppRoot() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #67 
This will allow the developers to specify an entirely different URL for the forecastle app instead of using the one from the ingress. Useful if you want to add subpaths etc to the existing URL or maybe if you have an external URL that acts as a gateway to the ingress