### PR TITLE
Remove if check from RBAC for custom resource

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
@@ -17,14 +17,12 @@ rules:
 - apiGroups: ["", "extensions"]
   resources: ["ingresses", "namespaces"]
   verbs: ["get", "list"]
-{{ if .Values.forecastle.createCustomResource }}
 - apiGroups:
   - forecastle.stakater.com
   resources:
   - '*'
   verbs:
   - '*'
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This fixes the issue that if you don't enable `createCustomResource` you get the following error:
```
time="2019-11-12T10:05:45Z" level=error msg="An error occurred while looking for forceastle CRD apps: forecastleapps.forecastle.stakater.com is forbidden: User \"system:serviceaccount:control:forecastle\" cannot list forecastleapps.forecastle.stakater.com at the cluster scope: no RBAC policy matched" _source="handlers/appsHandler.go:70"
```