### PR TITLE
Remove lifecycle for sidecar since it's only supported in kubernetes v1.18+

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
       - name: oauth-proxy
         image: openshift/oauth-proxy:latest
         imagePullPolicy: IfNotPresent
-        lifecycle:
-          type: Sidecar
         ports:
           - containerPort: 8443
             name: public


### PR DESCRIPTION
Remove lifecycle for sidecar since it's only supported in kubernetes v1.18+