### PR TITLE
Skip a ForecastleApp if URL cannot be determined

### DIFF
--- a/pkg/forecastle/crdapps/crdapps.go
+++ b/pkg/forecastle/crdapps/crdapps.go
@@ -67,7 +67,9 @@ func convertForecastleAppCustomResourcesToForecastleApps(clients kube.Clients, f
 		url, err := getURL(clients, forecastleApp)
 
 		if err != nil {
-			return nil, err
+			logger.Errorf("Skipping... Error fetching URL for forecastleApp with Name '%v' in Namespace '%v'. Error: %v", 
+				      forecastleApp.Name, forecastleApp.Namespace, err)
+			continue
 		}
 
 		apps = append(apps, forecastle.App{


### PR DESCRIPTION
Addresses #125 . Skips only specific app if it fails to provide a valid URL.