### PR TITLE
upgraded the CRD version to apiextensions.k8s.io/v1

### DIFF
--- a/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
+++ b/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com

--- a/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
+++ b/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
@@ -3,64 +3,66 @@ kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com
 spec:
+  conversion:
+    strategy: None
   group: forecastle.stakater.com
   names:
     kind: ForecastleApp
     listKind: ForecastleAppList
     plural: forecastleapps
     singular: forecastleapp
+  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            group:
-              type: string
-            icon:
-              type: string
-            instance:
-              type: string
-            name:
-              type: string
-            networkRestricted:
-              type: boolean
-            properties:
-              additionalProperties:
-                type: string
-              type: object
-            url:
-              type: string
-            urlFrom:
-              properties:
-                ingressRef:
-                  type: object
-                routeRef:
-                  type: object
-              type: object
-          required:
-          - name
-          - group
-          - icon
-          type: object
-        status:
-          type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              group:
+                type: string
+              icon:
+                type: string
+              instance:
+                type: string
+              name:
+                type: string
+              networkRestricted:
+                type: boolean
+              properties:
+                additionalProperties:
+                  type: string
+                type: object
+              url:
+                type: string
+              urlFrom:
+                properties:
+                  ingressRef:
+                    type: object
+                  routeRef:
+                    type: object
+                type: object
+            required:
+            - name
+            - group
+            - icon
+            type: object
+          status:
+            type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deployments/kubernetes/forecastle.yaml
+++ b/deployments/kubernetes/forecastle.yaml
@@ -31,67 +31,69 @@ kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com
 spec:
+  conversion:
+    strategy: None
   group: forecastle.stakater.com
   names:
     kind: ForecastleApp
     listKind: ForecastleAppList
     plural: forecastleapps
     singular: forecastleapp
+  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            group:
-              type: string
-            icon:
-              type: string
-            instance:
-              type: string
-            name:
-              type: string
-            networkRestricted:
-              type: boolean
-            properties:
-              additionalProperties:
-                type: string
-              type: object
-            url:
-              type: string
-            urlFrom:
-              properties:
-                ingressRef:
-                  type: object
-                routeRef:
-                  type: object
-              type: object
-          required:
-          - name
-          - group
-          - icon
-          type: object
-        status:
-          type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              group:
+                type: string
+              icon:
+                type: string
+              instance:
+                type: string
+              name:
+                type: string
+              networkRestricted:
+                type: boolean
+              properties:
+                additionalProperties:
+                  type: string
+                type: object
+              url:
+                type: string
+              urlFrom:
+                properties:
+                  ingressRef:
+                    type: object
+                  routeRef:
+                    type: object
+                type: object
+            required:
+            - name
+            - group
+            - icon
+            type: object
+          status:
+            type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 # Source: forecastle/templates/deployment.yaml
 apiVersion: apps/v1

--- a/deployments/kubernetes/forecastle.yaml
+++ b/deployments/kubernetes/forecastle.yaml
@@ -26,7 +26,7 @@ data:
 ---
 # Source: forecastle/templates/crd.yaml
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com

--- a/deployments/kubernetes/manifests/crd.yaml
+++ b/deployments/kubernetes/manifests/crd.yaml
@@ -6,64 +6,66 @@ kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com
 spec:
+  conversion:
+    strategy: None
   group: forecastle.stakater.com
   names:
     kind: ForecastleApp
     listKind: ForecastleAppList
     plural: forecastleapps
     singular: forecastleapp
+  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            group:
-              type: string
-            icon:
-              type: string
-            instance:
-              type: string
-            name:
-              type: string
-            networkRestricted:
-              type: boolean
-            properties:
-              additionalProperties:
-                type: string
-              type: object
-            url:
-              type: string
-            urlFrom:
-              properties:
-                ingressRef:
-                  type: object
-                routeRef:
-                  type: object
-              type: object
-          required:
-          - name
-          - group
-          - icon
-          type: object
-        status:
-          type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              group:
+                type: string
+              icon:
+                type: string
+              instance:
+                type: string
+              name:
+                type: string
+              networkRestricted:
+                type: boolean
+              properties:
+                additionalProperties:
+                  type: string
+                type: object
+              url:
+                type: string
+              urlFrom:
+                properties:
+                  ingressRef:
+                    type: object
+                  routeRef:
+                    type: object
+                type: object
+            required:
+            - name
+            - group
+            - icon
+            type: object
+          status:
+            type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deployments/kubernetes/manifests/crd.yaml
+++ b/deployments/kubernetes/manifests/crd.yaml
@@ -1,7 +1,7 @@
 ---
 # Source: forecastle/templates/crd.yaml
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: forecastleapps.forecastle.stakater.com


### PR DESCRIPTION
Currently newer version of k8s are throwing:
```
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/forecastleapps.forecastle.stakater.com unchanged
```

This PR upgrades the CRD version to apiextensions.k8s.io/v1