### PR TITLE
Add missing property for ingressRef

### DIFF
--- a/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
+++ b/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
@@ -53,6 +53,9 @@ spec:
                 properties:
                   ingressRef:
                     type: object
+                    properties:
+                      name:
+                        type: string
                   routeRef:
                     type: object
                 type: object


### PR DESCRIPTION
Forecastle CR is not working due to a missing property. This pull request fixes this. I have tested this also in our working Kubernetes Cluster