### PR TITLE
Enable ability to override Release.Namespace for target namespace

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/configmap.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "forecastle.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
 {{ include "forecastle.labels.stakater" . | indent 4 }}
 {{ include "forecastle.labels.chart" . | indent 4 }}

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
 {{ include "forecastle.labels.stakater" . | indent 4 }}
 {{ include "forecastle.labels.chart" . | indent 4 }}
   name: {{ template "forecastle.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   replicas: {{ .Values.forecastle.deployment.replicas }}
   revisionHistoryLimit: {{ .Values.forecastle.deployment.revisionHistoryLimit }}
@@ -31,7 +32,7 @@ spec:
       {{- if .Values.forecastle.deployment.resources }}
         resources:
 {{ toYaml .Values.forecastle.deployment.resources | indent 10 }}
-      {{- end }}        
+      {{- end }}
         volumeMounts:
         - name: {{ template "forecastle.name" . }}-config
           mountPath: /etc/forecastle
@@ -56,7 +57,7 @@ spec:
       {{- if .Values.forecastle.openshiftOauthProxy.resources }}
         resources:
 {{ toYaml .Values.forecastle.openshiftOauthProxy.resources | indent 10 }}
-      {{- end }}    
+      {{- end }}
       {{- end }}
       volumes:
       - name: {{ template "forecastle.name" . }}-config

--- a/deployments/kubernetes/chart/forecastle/templates/ingress.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/ingress.yaml
@@ -8,6 +8,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "forecastle.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
 {{ include "forecastle.labels.stakater" . | indent 4 }}
 {{ include "forecastle.labels.chart" . | indent 4 }}

--- a/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
@@ -51,4 +51,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "forecastle.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}

--- a/deployments/kubernetes/chart/forecastle/templates/route.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/route.yaml
@@ -3,6 +3,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ template "forecastle.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
 {{ include "forecastle.labels.stakater" . | indent 4 }}
 {{ include "forecastle.labels.chart" . | indent 4 }}

--- a/deployments/kubernetes/chart/forecastle/templates/service.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ include "forecastle.labels.chart" . | indent 4 }}
     expose: "{{ .Values.forecastle.service.expose }}"
   name: {{ template "forecastle.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   ports:
   {{- if .Values.forecastle.openshiftOauthProxy.enabled }}


### PR DESCRIPTION
Changing

namespace: {{ .Release.Namespace }}

to

namespace: {{ .Values.namespace | default .Release.Namespace }}

To add flexibility to deploy to its own namespace when used in an umbrella chart concept