### PR TITLE
patch helm chart rbac

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/rbac.yaml
@@ -35,8 +35,8 @@ rules:
   resources: ["ingressroutes"]
   verbs: ["get", "list"]
 - apiGroups: ["forecastle.stakater.com"]
-  resources: ["*"]
-  verbs: ["*"]
+  resources: ["forcastleapps"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Hi,

This PR update the helm chart and reduce cluster role permissions from the apiGroups 'forecastle.stakater.com' to comply with trivy security checks.

```
- category: Kubernetes Security Check
  checkID: KSV046
  description: Check whether role permits specific verb on wildcard resources
  messages:
    - Role permits specific verb on wildcard resource
  severity: CRITICAL
  title: No wildcard resource roles
```

The patch was tested again the lastest (v1.0.118) forcastle helm release.