### PR TITLE
Fix for Dockerfile smell DL4000

### DIFF
--- a/build/package/Dockerfile.build
+++ b/build/package/Dockerfile.build
@@ -4,7 +4,7 @@ COPY ./frontend ./
 RUN yarn install && yarn build
 
 FROM golang:1.13.1-alpine
-MAINTAINER "Stakater Team"
+LABEL maintainer="Stakater Team"
 
 RUN apk update
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "build/package/Dockerfile.build" contains the best practice violation [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4000 occurs when the deprecated MAINTAINER instruction is used.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the MAINTAINER instruction is replaced by an equivalent LABEL instruction as recommended by the official guidelines.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance