### PR TITLE
fix(helm): redundant container security contexts

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,7 @@ env:
   DOCKER_FILE_PATH: Dockerfile
   KUBERNETES_VERSION: "1.22.2"
   KIND_VERSION: "0.10.0"
+  HELM_VERSION: "3.16.3"
   REGISTRY: ghcr.io
 
 jobs:
@@ -21,10 +22,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.sha}}
-
-    # Setting up helm binary
-    - name: Set up Helm
-      uses: azure/setup-helm@v3
 
     - name: Set up Go
       id: go
@@ -40,11 +37,6 @@ jobs:
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
         golangci-lint run --timeout=10m ./...
-
-    - name: Helm Lint
-      run: |
-        cd deployments/kubernetes/chart/forecastle
-        helm lint
 
     - name: Generate Tag
       id: generate_tag
@@ -64,7 +56,6 @@ jobs:
         echo GHCR_IMAGE_REPOSITORY=${{env.REGISTRY}}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
     # To identify any broken changes in dockerfiles or dependencies
-
     - name: Build image
       uses: docker/build-push-action@v5
       with:
@@ -81,3 +72,24 @@ jobs:
           org.opencontainers.image.source=${{ github.event.repository.clone_url }}
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.revision=${{ github.sha }}
+
+  test-helm:
+    runs-on: ubuntu-latest
+    name: Test Helm
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.event.pull_request.head.sha}}
+
+    - uses: d3adb5/helm-unittest-action@v2
+      with:
+        helm-version: v${{ env.HELM_VERSION }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Helm Lint
+      run: |
+        cd deployments/kubernetes/chart/forecastle
+        helm lint

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -31,7 +31,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - securityContext: {{- toYaml .Values.forecastle.container.securityContext | nindent 12 }}
+      - {{- $containerSecurityContext := mustMergeOverwrite ((.Values.forecastle.container).securityContext | default dict) ((.Values.forecastle.deployment).securityContext | default dict) }}
+        {{- if $containerSecurityContext }}
+        securityContext: {{- toYaml $containerSecurityContext | nindent 12 }}
+        {{- end }}
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:
@@ -46,10 +49,6 @@ spec:
         volumeMounts:
         - name: {{ template "forecastle.name" . }}-config
           mountPath: /etc/forecastle
-      {{- with .Values.forecastle.deployment.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
       {{- if .Values.forecastle.openshiftOauthProxy.enabled }}
       - name: oauth-proxy
         image: "{{ default "stakater/oauth-proxy:v0.0.2" .Values.forecastle.openshiftOauthProxy.image }}"

--- a/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
@@ -1,0 +1,37 @@
+suite: Deployment
+
+templates:
+  - deployment.yaml
+  - configmap.yaml # dependency
+
+tests:
+  - it: includes container security context
+    template: deployment.yaml
+    set:
+      forecastle.deployment.securityContext: { allowPrivilegeEscalation: false }
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: includes container security context (deprecated) entries
+    template: deployment.yaml
+    set:
+      forecastle.container.securityContext: { allowPrivilegeEscalation: false }
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: merges container security context fields
+    template: deployment.yaml
+    set:
+      forecastle.container.securityContext: { allowPrivilegeEscalation: true }
+      forecastle.deployment.securityContext: { runAsNonRoot: true, allowPrivilegeEscalation: false }
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -43,18 +43,6 @@ forecastle:
     #     memory: 64Mi
   pod:
     annotations: {}
-  container:
-    securityContext:
-      {}
-      #privileged: false
-      #capabilities:
-      #  drop:
-      #    - ALL
-      #readOnlyRootFilesystem: true
-      #runAsNonRoot: true
-      #runAsUser: 1000
-      #runAsGroup: 1000
-      #allowPrivilegeEscalation: false
   podDisruptionBudget:
     {}
     #minAvailable: 90%

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -13,14 +13,10 @@ forecastle:
     annotations: {}
     affinity: {}
     nodeSelector: {}
-    securityContext: {}
+    podSecurityContext: {}
       #runAsNonRoot: true
       #  seccompProfile:
       #    type: RuntimeDefault
-    tolerations: {}
-  pod:
-    annotations: {}
-  container:
     securityContext: {}
       #privileged: false
       #capabilities:
@@ -31,6 +27,9 @@ forecastle:
       #runAsUser: 1000
       #runAsGroup: 1000
       #allowPrivilegeEscalation: false
+    tolerations: {}
+  pod:
+    annotations: {}
   resources: {}
     #limits:
     #  cpu: 100m


### PR DESCRIPTION
Fixes https://github.com/stakater/Forecastle/issues/428

- Remove `forecastle.container.securityContext` from `values.yaml`
- Remove duplicate container security context mapping
- Merge `forecastle.container.securityContext` and `forecastle.deployment.securityContext` to keep backward compatibility