### PR TITLE
Fix incorrect indentation for pod annotations in Helm template

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/api-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- with .Values.forecastle.pod.annotations }}
-{{- toYaml . | indent 8 }}
+{{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
       {{- with .Values.forecastle.deployment.imagePullSecrets }}


### PR DESCRIPTION
This PR fixes an issue in the `deployment.yaml` Helm template where `toYaml` was used with `indent` instead of `nindent`. The incorrect indentation could cause YAML parsing errors when deploying with certain configurations.

### Changes:
- Updated `{{- toYaml . | indent 8 }}` to `{{- toYaml . | nindent 8 }}` for `.Values.forecastle.pod.annotations`.

### Issue:
This fix resolves a YAML parsing error.

### Steps to Reproduce:

**helm version**

```
version.BuildInfo{Version:"v3.17.0", GitCommit:"301108edc7ac2a8ba79e4ebf5701b0b6ce6a31e4", GitTreeState:"clean", GoVersion:"go1.23.4"}
```

1. Add pod annotations in your values.yaml:
```yaml
forecastle:
  pod:
    annotations:
      example-annotation: "test-value"
```
2. Deploy the chart using:
	* helm install:
	```bash
	helm install forecastle stakater/forecastle --values values.yaml
	```
	* OR via Terraform helm_release:
	```tf
	resource "helm_release" "forecastle" {
	  name                = "forecastle"
	  chart               = "forecastle"
	  version             = "1.0.152-1"
	  namespace           = "default"
	
	  values = [
	    <<-EOT
	      forecastle:
	        pod:
	          annotations:
			    example-annotation = test-value
	    EOT
	  ]
	```
4. Observe the error during deployment:

```bash
helm template forecastle ./ -f value.yaml
Error: YAML parse error on forecastle/templates/deployment.yaml: error converting YAML to JSON: yaml: line 29: mapping values are not allowed in this context
```
