### PR TITLE
feat: add oidcProxy support to Helm chart

### DIFF
--- a/deployments/kubernetes/chart/forecastle/Chart.yaml
+++ b/deployments/kubernetes/chart/forecastle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: forecastle
 description: forecastle chart that runs on kubernetes
 icon: https://github.com/stakater/Forecastle/raw/master/assets/web/forecastle-round-100px.png
-version: 1.2.0
+version: 1.3.0
 appVersion: "v2.0.0"
 keywords:
   - forecastle

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -77,8 +77,11 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.forecastle.oidcProxy.enabled }}
-      - name: oauth-proxy
-        image: "{{ .Values.forecastle.oidcProxy.image }}"
+      {{- if .Values.forecastle.openshiftOauthProxy.enabled }}
+      {{- fail "openshiftOauthProxy and oidcProxy cannot both be enabled" }}
+      {{- end }}
+      - name: oidc-proxy
+        image: {{ required "oidcProxy.image is required when oidcProxy is enabled" .Values.forecastle.oidcProxy.image | quote }}
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8443
@@ -86,9 +89,9 @@ spec:
         args:
           - --https-address=:8443
           - --provider=oidc
-          - --oidc-issuer-url={{ .Values.forecastle.oidcProxy.issuerUrl }}
-          - --client-id={{ .Values.forecastle.oidcProxy.clientId }}
-          - --redirect-url={{ .Values.forecastle.oidcProxy.redirectUrl }}
+          - --oidc-issuer-url={{ required "oidcProxy.issuerUrl is required" .Values.forecastle.oidcProxy.issuerUrl }}
+          - --client-id={{ required "oidcProxy.clientId is required" .Values.forecastle.oidcProxy.clientId }}
+          - --redirect-url={{ required "oidcProxy.redirectUrl is required" .Values.forecastle.oidcProxy.redirectUrl }}
           - --upstream=http://localhost:3000
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
@@ -98,13 +101,13 @@ spec:
           - name: OAUTH2_PROXY_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.forecastle.oidcProxy.clientSecretRef.name }}
-                key: {{ .Values.forecastle.oidcProxy.clientSecretRef.key }}
+                name: {{ required "oidcProxy.clientSecretRef.name is required" .Values.forecastle.oidcProxy.clientSecretRef.name }}
+                key: {{ required "oidcProxy.clientSecretRef.key is required" .Values.forecastle.oidcProxy.clientSecretRef.key }}
           - name: OAUTH2_PROXY_COOKIE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.forecastle.oidcProxy.cookieSecretRef.name }}
-                key: {{ .Values.forecastle.oidcProxy.cookieSecretRef.key }}
+                name: {{ required "oidcProxy.cookieSecretRef.name is required" .Values.forecastle.oidcProxy.cookieSecretRef.name }}
+                key: {{ required "oidcProxy.cookieSecretRef.key is required" .Values.forecastle.oidcProxy.cookieSecretRef.key }}
         volumeMounts:
           - mountPath: /etc/tls/private
             name: oauth-proxy-tls

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -76,6 +76,47 @@ spec:
 {{ toYaml .Values.forecastle.openshiftOauthProxy.resources | indent 10 }}
       {{- end }}
       {{- end }}
+      {{- if .Values.forecastle.oidcProxy.enabled }}
+      - name: oauth-proxy
+        image: "{{ .Values.forecastle.oidcProxy.image }}"
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8443
+            name: public
+        args:
+          - --https-address=:8443
+          - --provider=oidc
+          - --oidc-issuer-url={{ .Values.forecastle.oidcProxy.issuerUrl }}
+          - --client-id={{ .Values.forecastle.oidcProxy.clientId }}
+          - --redirect-url={{ .Values.forecastle.oidcProxy.redirectUrl }}
+          - --upstream=http://localhost:3000
+          - --tls-cert=/etc/tls/private/tls.crt
+          - --tls-key=/etc/tls/private/tls.key
+          - --email-domain=*
+          - --scope={{ .Values.forecastle.oidcProxy.scopes }}
+        env:
+          - name: OAUTH2_PROXY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.forecastle.oidcProxy.clientSecretRef.name }}
+                key: {{ .Values.forecastle.oidcProxy.clientSecretRef.key }}
+          - name: OAUTH2_PROXY_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.forecastle.oidcProxy.cookieSecretRef.name }}
+                key: {{ .Values.forecastle.oidcProxy.cookieSecretRef.key }}
+        volumeMounts:
+          - mountPath: /etc/tls/private
+            name: oauth-proxy-tls
+      {{- with .Values.forecastle.oidcProxy.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- if .Values.forecastle.oidcProxy.resources }}
+        resources:
+{{ toYaml .Values.forecastle.oidcProxy.resources | indent 10 }}
+      {{- end }}
+      {{- end }}
       volumes:
       - name: {{ template "forecastle.name" . }}-config
         configMap:
@@ -84,6 +125,11 @@ spec:
       - name: openshift-oauth-proxy-tls
         secret:
           secretName: openshift-oauth-proxy-tls
+      {{- end }}
+      {{- if .Values.forecastle.oidcProxy.enabled }}
+      - name: oauth-proxy-tls
+        secret:
+          secretName: oauth-proxy-tls
       {{- end }}
       serviceAccountName: {{ template "forecastle.name" . }}
       {{- with .Values.forecastle.deployment.podSecurityContext }}

--- a/deployments/kubernetes/chart/forecastle/templates/service.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: {{ .Values.namespace | default .Release.Namespace }}
 spec:
   ports:
-  {{- if .Values.forecastle.openshiftOauthProxy.enabled }}
+  {{- if or .Values.forecastle.openshiftOauthProxy.enabled .Values.forecastle.oidcProxy.enabled }}
   - name: http
     port: 443
     protocol: TCP

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -2,7 +2,7 @@ forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
-    version: 1.2.0
+    version: 1.3.0
   namespace: default
   image:
     name: stakater/forecastle

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -100,6 +100,21 @@ forecastle:
     #     memory: 64Mi
     # image: stakater/oauth-proxy:v0.0.2
     securityContext: {}
+  oidcProxy:
+    enabled: false
+    image: ""
+    issuerUrl: ""
+    clientId: ""
+    redirectUrl: ""
+    scopes: "openid email profile"
+    clientSecretRef:
+      name: ""
+      key: ""
+    cookieSecretRef:
+      name: ""
+      key: ""
+    resources: {}
+    securityContext: {}
   service:
     annotations: {}
     expose: "false"


### PR DESCRIPTION
## Summary
- Add generic OIDC proxy sidecar option (`oidcProxy`) alongside the existing `openshiftOauthProxy`
- Supports configurable issuer URL, client ID, client/cookie secret refs, redirect URL, and scopes
- Bumps chart version to 1.3.0

## Test plan
- [ ] `helm template` with `oidcProxy.enabled=true` renders oauth-proxy sidecar with `--provider=oidc`
- [ ] `helm template` with `openshiftOauthProxy.enabled=true` still works as before
- [ ] Both disabled by default — no breaking change