### PR TITLE
feat: templatize oidcProxy args for downstream flexibility

### DIFF
--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -93,10 +93,13 @@ spec:
           - --client-id={{ required "oidcProxy.clientId is required" .Values.forecastle.oidcProxy.clientId }}
           - --redirect-url={{ required "oidcProxy.redirectUrl is required" .Values.forecastle.oidcProxy.redirectUrl }}
           - --upstream=http://localhost:3000
-          - --tls-cert=/etc/tls/private/tls.crt
-          - --tls-key=/etc/tls/private/tls.key
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-key-file=/etc/tls/private/tls.key
           - --email-domain=*
           - --scope={{ .Values.forecastle.oidcProxy.scopes }}
+          {{- range .Values.forecastle.oidcProxy.extraArgs }}
+          - {{ . }}
+          {{- end }}
         env:
           - name: OAUTH2_PROXY_CLIENT_SECRET
             valueFrom:

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -102,11 +102,13 @@ forecastle:
     securityContext: {}
   oidcProxy:
     enabled: false
-    image: ""
+    image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
     issuerUrl: ""
     clientId: ""
     redirectUrl: ""
     scopes: "openid email profile"
+    extraArgs:
+      - --skip-provider-button=true
     clientSecretRef:
       name: ""
       key: ""


### PR DESCRIPTION
Move TLS flags and skip-provider-button out of hardcoded args into a configurable extraArgs list. Downstream charts can override these without needing upstream changes.