### PR TITLE
feat: integrate gateway api endpoint for chart

### DIFF
--- a/deployments/kubernetes/chart/forecastle/Chart.yaml
+++ b/deployments/kubernetes/chart/forecastle/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: forecastle
 description: forecastle chart that runs on kubernetes
 icon: https://github.com/stakater/Forecastle/raw/master/assets/web/forecastle-round-100px.png
-version: 1.4.0
-appVersion: "v2.0.0"
+version: 1.5.0
+appVersion: "v2.0.1"
 keywords:
   - forecastle
   - kubernetes

--- a/deployments/kubernetes/chart/forecastle/templates/httproute.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.forecastle.httpRoute.enabled -}}
+{{- $name := include "forecastle.name" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+{{ include "forecastle.labels.stakater" . | indent 4 }}
+{{ include "forecastle.labels.chart" . | indent 4 }}
+  {{- with .Values.forecastle.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.forecastle.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.forecastle.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.forecastle.httpRoute.rules }}
+    -
+      {{- if .name }}
+      name: {{ .name }}
+      {{- end }}
+      {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+      {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 4 }}
+      {{- else }}
+        - name: {{ $name }}
+          port: http
+          weight: 1
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -2,11 +2,11 @@ forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
-    version: 1.3.0
+    version: 1.5.0
   namespace: default
   image:
     name: stakater/forecastle
-    tag: v2.0.0
+    tag: v2.0.1
   deployment:
     replicas: 1
     revisionHistoryLimit: 2
@@ -120,6 +120,16 @@ forecastle:
   service:
     annotations: {}
     expose: "false"
+  httpRoute:
+    enabled: false
+    annotations: {}
+    parentRefs: []
+    hostnames: []
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
   ingress:
     enabled: false
     annotations: {}
@@ -133,7 +143,6 @@ forecastle:
     #- hosts:
     #  - forecastle.example.com
     #  secretName: ~
-
   route:
     enabled: false
     annotations: {}


### PR DESCRIPTION
The Gateway API had been established as the new standard as an alternative for Ingress resources. With this change it's possible to deploy the HTTPRoute resource directly as part of the chart.