### PR TITLE
fix: ensure Helm chart values are aligned with templates

### DIFF
--- a/deployments/kubernetes/chart/forecastle/.gitignore
+++ b/deployments/kubernetes/chart/forecastle/.gitignore
@@ -1,0 +1,3 @@
+# helm unittest
+__snapshot__
+**/.debug

--- a/deployments/kubernetes/chart/forecastle/Chart.yaml
+++ b/deployments/kubernetes/chart/forecastle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: forecastle
 description: forecastle chart that runs on kubernetes
 icon: https://github.com/stakater/Forecastle/raw/master/assets/web/forecastle-round-100px.png
-version: 1.4.0
+version: 1.5.0
 appVersion: "v2.0.0"
 keywords:
   - forecastle

--- a/deployments/kubernetes/chart/forecastle/Chart.yaml
+++ b/deployments/kubernetes/chart/forecastle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: forecastle
 description: forecastle chart that runs on kubernetes
 icon: https://github.com/stakater/Forecastle/raw/master/assets/web/forecastle-round-100px.png
-version: 1.5.0
+version: 2.0.0
 appVersion: "v2.0.1"
 keywords:
   - forecastle

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -31,17 +31,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - {{- $containerSecurityContext := mustMergeOverwrite ((.Values.forecastle.container).securityContext | default dict) ((.Values.forecastle.deployment).securityContext | default dict) }}
-        {{- if $containerSecurityContext }}
-        securityContext: {{- toYaml $containerSecurityContext | nindent 12 }}
+      - name: {{ template "forecastle.name" . }}
+        image: "{{ .Values.forecastle.image.name }}:{{ .Values.forecastle.image.tag }}"
+        {{- with .Values.forecastle.deployment.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "{{ .Values.forecastle.image.name }}:{{ .Values.forecastle.image.tag }}"
-        name: {{ template "forecastle.name" . }}
       {{- if .Values.forecastle.deployment.resources }}
         resources:
 {{ toYaml .Values.forecastle.deployment.resources | indent 10 }}

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           mountPath: /etc/forecastle
       {{- if .Values.forecastle.openshiftOauthProxy.enabled }}
       - name: oauth-proxy
-        image: "{{ default "stakater/oauth-proxy:v0.0.2" .Values.forecastle.openshiftOauthProxy.image }}"
+        image: {{ .Values.forecastle.openshiftOauthProxy.image | quote }}
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8443

--- a/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
@@ -5,33 +5,22 @@ templates:
   - configmap.yaml # dependency
 
 tests:
-  - it: includes container security context
+  - it: includes pod security context when specified
     template: deployment.yaml
     set:
-      forecastle.deployment.securityContext: { allowPrivilegeEscalation: false }
+      forecastle.deployment.podSecurityContext:
+        runAsNonRoot: true
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-
-  - it: includes container security context (deprecated) entries
-    template: deployment.yaml
-    set:
-      forecastle.container.securityContext: { allowPrivilegeEscalation: false }
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-
-  - it: merges container security context fields
-    template: deployment.yaml
-    set:
-      forecastle.container.securityContext: { allowPrivilegeEscalation: true }
-      forecastle.deployment.securityContext: { runAsNonRoot: true, allowPrivilegeEscalation: false }
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          path: spec.template.spec.securityContext.runAsNonRoot
           value: true
+
+  - it: includes forecastle container security context when specified
+    template: deployment.yaml
+    set:
+      forecastle.deployment.securityContext:
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
@@ -12,7 +12,6 @@ tests:
         not: true
       - hasDocuments:
           count: 0
-      - matchSnapshot: {}
 
   - it: should set tls if given
     set:

--- a/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
@@ -1,0 +1,25 @@
+suite: Deployment
+
+templates:
+  - ingress.yaml
+
+tests:
+  - it: should render nothing if not enabled
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+        not: true
+      - hasDocuments:
+          count: 0
+      - matchSnapshot: {}
+
+  - it: should set tls if given
+    set:
+      forecastle.ingress.enabled: true
+      forecastle.ingress.tls:
+        - secretName: my-tls-secret
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-tls-secret

--- a/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/ingress_test.yaml
@@ -1,4 +1,4 @@
-suite: Deployment
+suite: Ingress
 
 templates:
   - ingress.yaml

--- a/deployments/kubernetes/chart/forecastle/tests/nameOverride_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/nameOverride_test.yaml
@@ -1,0 +1,27 @@
+suite: Override Resource Names
+
+templates:
+  - "templates/*.yaml"
+
+tests:
+  - it: should generate resource names based on Helm chart name by default
+    documentSelector:
+      path: metadata.name
+      matchMany: true
+      skipEmptyTemplates: true
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^forecastle
+
+  - it: should generate resource names based on nameOverride value when specified
+    set:
+      nameOverride: custom-forecastle
+    documentSelector:
+      path: metadata.name
+      matchMany: true
+      skipEmptyTemplates: true
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^custom-forecastle

--- a/deployments/kubernetes/chart/forecastle/tests/namespace_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/namespace_test.yaml
@@ -1,0 +1,30 @@
+suite: Override Namespace
+
+templates:
+  - "templates/*.yaml"
+
+release:
+  namespace: my-namespace
+
+tests:
+  - it: should use Helm release namespace by default
+    documentSelector:
+      path: metadata.namespace
+      matchMany: true
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+
+  - it: should use namespace value when specified
+    set:
+      namespace: custom-namespace
+    documentSelector:
+      path: metadata.namespace
+      matchMany: true
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -128,10 +128,10 @@ forecastle:
         paths:
           - path: /
             pathType: Prefix
-    #tls:
-    #- hosts:
-    #  - forecastle.example.com
-    #  secretName: ~
+    tls: []
+      # - hosts:
+      #     - forecastle.example.com
+      #   secretName: ~
 
   route:
     enabled: false

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -13,6 +13,8 @@ forecastle:
     annotations: {}
     affinity: {}
     nodeSelector: {}
+    # Pod security context
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
     podSecurityContext:
       {}
       # runAsNonRoot: true
@@ -20,6 +22,8 @@ forecastle:
       # fsGroup: 10001
       # seccompProfile:
       #   type: RuntimeDefault
+    # Container security context
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     securityContext:
       {}
       # runAsNonRoot: true

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -15,8 +15,7 @@ forecastle:
     nodeSelector: {}
     # Pod security context
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-    podSecurityContext:
-      {}
+    podSecurityContext: {}
       # runAsNonRoot: true
       # runAsUser: 10001
       # fsGroup: 10001
@@ -24,8 +23,7 @@ forecastle:
       #   type: RuntimeDefault
     # Container security context
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    securityContext:
-      {}
+    securityContext: {}
       # runAsNonRoot: true
       # runAsUser: 10002
       # runAsGroup: 10002
@@ -39,18 +37,17 @@ forecastle:
       #   type: RuntimeDefault
     tolerations: {}
     resources: {}
-    #   requests:
-    #     cpu: 100m
-    #     memory: 32Mi
-    #   limits:
-    #     cpu: 200m
-    #     memory: 64Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 32Mi
+      # limits:
+      #   cpu: 200m
+      #   memory: 64Mi
   pod:
     annotations: {}
-  podDisruptionBudget:
-    {}
-    #minAvailable: 90%
-    #maxUnavailable: 10%
+  podDisruptionBudget: {}
+    # minAvailable: 90%
+    # maxUnavailable: 10%
   networkPolicy:
     enabled: false
     ingress:

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -43,6 +43,7 @@ forecastle:
       # limits:
       #   cpu: 200m
       #   memory: 64Mi
+    imagePullSecrets: []
   pod:
     annotations: {}
   podDisruptionBudget: {}

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -90,8 +90,6 @@ forecastle:
     # Auto-detected from X-Forwarded-Prefix header if not set.
     # Leave empty for root path hosting.
     basePath:
-  proxy:
-    enabled: false
   openshiftOauthProxy:
     enabled: false
     image: stakater/oauth-proxy:v0.0.2

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -1,10 +1,11 @@
 nameOverride:
+namespace:
+
 forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
     version: 1.3.0
-  namespace: default
   image:
     name: stakater/forecastle
     tag: v2.0.0

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -5,7 +5,7 @@ forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
-    version: 1.3.0
+    version: 1.5.0
   image:
     name: stakater/forecastle
     tag: v2.0.0

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -94,15 +94,15 @@ forecastle:
     enabled: false
   openshiftOauthProxy:
     enabled: false
+    image: stakater/oauth-proxy:v0.0.2
     serviceAccountAnnotations: {}
     resources: {}
-    #   requests:
-    #     cpu: 100m
-    #     memory: 32Mi
-    #   limits:
-    #     cpu: 200m
-    #     memory: 64Mi
-    # image: stakater/oauth-proxy:v0.0.2
+      # requests:
+      #   cpu: 100m
+      #   memory: 32Mi
+      # limits:
+      #   cpu: 200m
+      #   memory: 64Mi
     securityContext: {}
   oidcProxy:
     enabled: false

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -1,3 +1,4 @@
+nameOverride:
 forecastle:
   labels:
     group: com.stakater.platform

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -5,7 +5,7 @@ forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
-    version: 1.5.0
+    version: 2.0.0
   image:
     name: stakater/forecastle
     tag: v2.0.1


### PR DESCRIPTION
Key changes:
- removed `forecastle.container.securityContext` support and merging logic with `forecastle.deployment.securityContext`; seemed like legacy stuff, clear usage of `forecastle.deployment.securityContext` remains untouched
- moved `forecastle.namepace` value to `namepace` - a fix so namespace can actually be overridden, currently no-op
- added values that are referenced in templates, but missing in `values.yaml` for visibility:
  - `nameOverride`
  - `forecastle.deployment.imagePullSecrets`
  - `ingress.tls`

Minor enhancements:
- removed `forecastle.proxy` value - not referenced in templates
- moved default value for `openshiftOauthProxy.image` from template to `values.yaml` for visibility
- `values.yaml` formatting
- added `.gitignore` to exclude helm-unittest artifacts
- added helm unit tests to cover changes