### PR TITLE
feat: add container args support in Helm chart

### DIFF
--- a/deployments/kubernetes/chart/forecastle/Chart.yaml
+++ b/deployments/kubernetes/chart/forecastle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: forecastle
 description: forecastle chart that runs on kubernetes
 icon: https://github.com/stakater/Forecastle/raw/master/assets/web/forecastle-round-100px.png
-version: 2.0.0
+version: 2.1.0
 appVersion: "v2.0.1"
 keywords:
   - forecastle

--- a/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/forecastle/templates/deployment.yaml
@@ -41,10 +41,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      {{- if .Values.forecastle.deployment.pprof.enabled }}
+      {{- if or .Values.forecastle.deployment.args .Values.forecastle.deployment.pprof.enabled }}
         args:
+      {{- with .Values.forecastle.deployment.args }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.forecastle.deployment.pprof.enabled }}
         - --enable-pprof
         - --pprof-port={{ .Values.forecastle.deployment.pprof.port }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.forecastle.deployment.pprof.enabled }}
         ports:
         - name: pprof
           containerPort: {{ .Values.forecastle.deployment.pprof.port }}

--- a/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
+++ b/deployments/kubernetes/chart/forecastle/tests/deployment_test.yaml
@@ -24,3 +24,53 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
+
+  - it: includes forecastle container arg and specifies port when pprof is enabled
+    template: deployment.yaml
+    set:
+      forecastle.deployment.pprof.enabled: true
+      forecastle.deployment.pprof.port: 7070
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --enable-pprof
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --pprof-port=7070
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: pprof
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 7070
+
+  - it: includes forecastle container args when specified
+    template: deployment.yaml
+    set:
+      forecastle.deployment.args:
+        - --cache-interval=45s
+        - --port=8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --cache-interval=45s
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --port=8080
+
+  - it: includes both custom args and pprof arg when specified together
+    template: deployment.yaml
+    set:
+      forecastle.deployment.args:
+        - --cache-interval=45s
+      forecastle.deployment.pprof.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --cache-interval=45s
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --enable-pprof
+      - equal:
+          path: spec.template.spec.containers[0].args[2]
+          value: --pprof-port=6060

--- a/deployments/kubernetes/chart/forecastle/values.yaml
+++ b/deployments/kubernetes/chart/forecastle/values.yaml
@@ -5,7 +5,7 @@ forecastle:
   labels:
     group: com.stakater.platform
     provider: stakater
-    version: 2.0.0
+    version: 2.1.0
   image:
     name: stakater/forecastle
     tag: v2.0.1
@@ -37,6 +37,9 @@ forecastle:
       # allowPrivilegeEscalation: false
       # seccompProfile:
       #   type: RuntimeDefault
+    # CLI flags for the main Forecastle container
+    # ref: https://github.com/stakater/Forecastle#command-line-flags
+    args: []
     tolerations: {}
     # pprof debug server for live profiling (CPU/heap/goroutine dumps).
     # Disabled by default; reach it via `kubectl port-forward` on pprof.port.


### PR DESCRIPTION
Adding container arguments support in Helm chart (personally, missing cache configuration), so they can be passed via values, e.g.:

```yaml
forecastle:
  deployment:
    args:
      - --cache-interval=60s
```

Recently added `pprof` configuration kept untouched; may be subject to improve